### PR TITLE
change json content-type to application/json

### DIFF
--- a/src/main/java/top/dteam/dgate/utils/RequestUtils.java
+++ b/src/main/java/top/dteam/dgate/utils/RequestUtils.java
@@ -30,14 +30,14 @@ public class RequestUtils {
 
     public void request(HttpMethod method, String host, int port, String url, JsonObject data, Handler<SimpleResponse> handler) {
         httpClient.request(method, port, host, url, defaultResponseHandler(handler))
-                .setChunked(true).putHeader("content-type", "text/json").end(data.toString());
+                .setChunked(true).putHeader("content-type", "application/json").end(data.toString());
     }
 
     public void requestWithJwtToken(HttpMethod method, String host, int port, String url, JsonObject data, String token,
                                     Handler<SimpleResponse> handler) {
         httpClient.request(method, port, host, url, defaultResponseHandler(handler))
                 .setChunked(true)
-                .putHeader("content-type", "text/json")
+                .putHeader("content-type", "application/json")
                 .putHeader("Authorization", String.format("Bearer %s", token))
                 .end(data.toString());
     }

--- a/src/main/java/top/dteam/dgate/utils/Utils.java
+++ b/src/main/java/top/dteam/dgate/utils/Utils.java
@@ -34,7 +34,7 @@ public class Utils {
     public static void fireJsonResponse(HttpServerResponse response, int statusCode, Map payload) {
         response.setStatusCode(statusCode);
         JsonObject jsonObject = new JsonObject(payload);
-        response.putHeader("content-type", "text/json; charset=utf-8").end(jsonObject.toString());
+        response.putHeader("content-type", "application/json; charset=utf-8").end(jsonObject.toString());
     }
 
     public static JWTAuth createAuthProvider(Vertx vertx) {


### PR DESCRIPTION
按照[RFC4627](https://www.ietf.org/rfc/rfc4627.txt)的规定，`json`的MIME type应为`application/json`。而`text/json`是不符合规范的。