### PR TITLE
fix warning in src/main/resource/logback.groovy

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -461,3 +461,14 @@ apiGateway {
 }
 ……
 ~~~
+
+### 日志级别
+默认情况下，dgate本身的日志将以`DEBUG`级别输出，其他第三方类库将以`WARN`级别输出。可以通过设置`DGATE_LOG_LEVEL`这个`System property`或环境变量覆盖这个默认值。
+
+例如:
+
+```bash
+# 以下两种方式等效,如果同时设置，则system property优先使用
+java -DDGATE_LOG_LEVEL=WARN -jar dgate-0.1-fat.jar
+DGATE_LOG_LEVEL=WARN java -jar dgate-0.1-fat.jar
+```

--- a/src/main/resources/logback.groovy
+++ b/src/main/resources/logback.groovy
@@ -1,30 +1,33 @@
-import ch.qos.logback.classic.PatternLayout
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder
 import ch.qos.logback.core.ConsoleAppender
 import ch.qos.logback.core.rolling.RollingFileAppender
-import ch.qos.logback.core.rolling.TimeBasedRollingPolicy
-
-import static ch.qos.logback.classic.Level.DEBUG
-import static ch.qos.logback.classic.Level.WARN
+import ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy
 
 appender("Console", ConsoleAppender) {
-    layout(PatternLayout) {
+    encoder(PatternLayoutEncoder) {
         pattern = "%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"
     }
 }
 
 appender("R", RollingFileAppender) {
     file = "dgate.log"
-    rollingPolicy(TimeBasedRollingPolicy) {
-        fileNamePattern = "%d{yyyy-MM-dd}_dgate.log"
-        maxHistory = 7
-    }
-    layout(PatternLayout) {
+    encoder(PatternLayoutEncoder) {
         pattern = "%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"
+    }
+    rollingPolicy(SizeAndTimeBasedRollingPolicy) {
+        fileNamePattern = "dgate_%d{yyyy-MM-dd}.%i.log"
+        maxFileSize = "10MB"
+        maxHistory = 7
+        totalSizeCap = "500MB"
     }
 }
 
+logger("io.vertx", Level.WARN)
+logger("io.netty", Level.WARN)
+logger("in ch.qos.logback", Level.WARN)
 
-logger("io.vertx", WARN)
-logger("io.netty", WARN)
+final String DGATE_LOG_LEVEL = System.getProperty("DGATE_LOG_LEVEL") ?:
+        System.getenv("DGATE_LOG_LEVEL")
 
-root(DEBUG, ["Console", "R"])
+root(Level.valueOf(DGATE_LOG_LEVEL), ["Console", "R"])

--- a/src/main/resources/logback.groovy
+++ b/src/main/resources/logback.groovy
@@ -25,7 +25,7 @@ appender("R", RollingFileAppender) {
 
 logger("io.vertx", Level.WARN)
 logger("io.netty", Level.WARN)
-logger("in ch.qos.logback", Level.WARN)
+logger("ch.qos.logback", Level.WARN)
 
 final String DGATE_LOG_LEVEL = System.getProperty("DGATE_LOG_LEVEL") ?:
         System.getenv("DGATE_LOG_LEVEL")


### PR DESCRIPTION
按照[官方文档](https://logback.qos.ch/codes.html#layoutInsteadOfEncoder)的说明，`Layout`的配置已经放在[`encoder`](https://logback.qos.ch/manual/encoders.html)中了，因此将layout的配置放入encoder中消除`This appender no longer admits a layout as a sub-component, set an encoder instead.`这个警告。

另外，添加了`DGATE_LOG_LEVEL`这个属性，允许从`System.getProperty("DGATE_LOG_LEVEL")`或`System.getenv(DGATE_LOG_LEVEL)`覆盖默认的日志级别。