### PR TITLE
set log file rolling policy to FixedWindowRollingPolicy

### DIFF
--- a/src/main/resources/logback.groovy
+++ b/src/main/resources/logback.groovy
@@ -2,24 +2,27 @@ import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.encoder.PatternLayoutEncoder
 import ch.qos.logback.core.ConsoleAppender
 import ch.qos.logback.core.rolling.RollingFileAppender
-import ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy
+import ch.qos.logback.core.rolling.FixedWindowRollingPolicy
+import ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy
 
 appender("Console", ConsoleAppender) {
     encoder(PatternLayoutEncoder) {
-        pattern = "%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"
+        pattern = "%d [%thread] %-5level %logger{36} - %msg%n"
     }
 }
 
 appender("R", RollingFileAppender) {
     file = "dgate.log"
     encoder(PatternLayoutEncoder) {
-        pattern = "%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"
+        pattern = "%d [%thread] %-5level %logger{36} - %msg%n"
     }
-    rollingPolicy(SizeAndTimeBasedRollingPolicy) {
-        fileNamePattern = "dgate_%d{yyyy-MM-dd}.%i.log"
+    rollingPolicy(FixedWindowRollingPolicy) {
+        fileNamePattern = "dgate.log.%i"
+        minIndex = 1
+        maxIndex = 10
+    }
+    triggeringPolicy(SizeBasedTriggeringPolicy) {
         maxFileSize = "10MB"
-        maxHistory = 7
-        totalSizeCap = "500MB"
     }
 }
 


### PR DESCRIPTION
设置log滚动策略为[`FixedWindowRollingPolicy`](https://logback.qos.ch/manual/appenders.html#FixedWindowRollingPolicy)，之前的`SizeAndTimeBasedRollingPolicy`似乎并不会对一天之内的日志进行删除处理，导致跑完压力测试之后日志非常巨大(100GB+)。

因此改用`FixedWindowRollingPolicy`，按照`SizeBasedTriggeringPolicy`策略滚动日志。