### PR TITLE
remove CacheLocator.close() from vertx stop method

### DIFF
--- a/src/main/java/top/dteam/dgate/MainVerticle.java
+++ b/src/main/java/top/dteam/dgate/MainVerticle.java
@@ -17,9 +17,4 @@ public class MainVerticle extends AbstractVerticle {
                 .forEach(apiGatewayConfig -> vertx.deployVerticle(new ApiGateway(apiGatewayConfig)));
 
     }
-
-    @Override
-    public void stop() {
-        CacheLocator.close();
-    }
 }

--- a/src/test/groovy/top/dteam/dgate/config/ConfPropertySpec.groovy
+++ b/src/test/groovy/top/dteam/dgate/config/ConfPropertySpec.groovy
@@ -10,6 +10,7 @@ class ConfPropertySpec extends Specification {
         then:
         ApiGatewayRepository.respository.size() == 1
         with(ApiGatewayRepository.respository[0]) {
+            name == 'gateway2'
             port == 7002
             host == '0.0.0.0'
         }
@@ -22,10 +23,12 @@ class ConfPropertySpec extends Specification {
         then:
         ApiGatewayRepository.respository.size() == 2
         with(ApiGatewayRepository.respository[0]) {
+            name == 'gateway1'
             port == 7001
             host == '0.0.0.0'
         }
         with(ApiGatewayRepository.respository[1]) {
+            name == 'gateway3'
             port == 7003
             host == '0.0.0.0'
         }


### PR DESCRIPTION
原来的做法画蛇添足了。vertx在stop的时候内部就已经会关闭ignite实例了，如果在stop中再调用一次ignite.close，反而可能会引发以下异常:

```
2017-07-28 11:24:54,361 [vert.x-eventloop-thread-5] ERROR io.vertx.core.impl.ContextImpl - Unhandled exception
java.lang.IllegalStateException: Cache has been closed or destroyed: __vertx.haInfo
	at org.apache.ignite.internal.processors.cache.GridCacheGateway.enter(GridCacheGateway.java:160)
	at org.apache.ignite.internal.processors.cache.IgniteCacheProxy.onEnter(IgniteCacheProxy.java:2264)
	at org.apache.ignite.internal.processors.cache.IgniteCacheProxy.getAndRemove(IgniteCacheProxy.java:1513)
	at io.vertx.spi.cluster.ignite.impl.MapImpl.remove(MapImpl.java:92)
	at io.vertx.core.impl.HAManager.stop(HAManager.java:209)
	at io.vertx.core.impl.VertxImpl.lambda$null$9(VertxImpl.java:505)
	at io.vertx.core.impl.DeploymentManager.lambda$undeployAll$3(DeploymentManager.java:236)
	at io.vertx.core.impl.DeploymentManager.lambda$reportResult$6(DeploymentManager.java:396)
	at io.vertx.core.impl.ContextImpl.lambda$wrapTask$2(ContextImpl.java:337)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:163)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:403)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:445)
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:858)
	at java.lang.Thread.run(Thread.java:748)
```